### PR TITLE
Update metadata_reader.py

### DIFF
--- a/fastafunk/metadata_reader.py
+++ b/fastafunk/metadata_reader.py
@@ -53,7 +53,7 @@ class MetadataReader:
                     self.where_column_dict[column] = []
                 regex = re.compile(regex)
                 for original_column in self.columns:
-                    match = re.search(regex, original_column)
+                    match = re.fullmatch(regex, original_column)
                     if match:
                         self.where_column_dict[column].append(original_column)
                 if column not in self.columns:


### PR DESCRIPTION
Changed re.search to re.fullmatch.
In the fastafunk fetch command, the regex used in the --where-column flag could match to multiple column names with re.search.
With re.search, a regex could match exactly to a given column, but it could also match to another column if the regex were a substring of the column name.
For example, if you used --where-column new_col_name=sample and your metadata had column names 'sample' and 'sample_date', the later column would be used.